### PR TITLE
Otherwise a reconnect could be not work.

### DIFF
--- a/iothub_client/samples/iothub_client_c2d_streaming_proxy_sample/iothub_client_c2d_streaming_proxy_sample.c
+++ b/iothub_client/samples/iothub_client_c2d_streaming_proxy_sample/iothub_client_c2d_streaming_proxy_sample.c
@@ -358,6 +358,8 @@ static DEVICE_STREAM_C2D_RESPONSE* streamRequestCallback(const DEVICE_STREAM_C2D
     (void)context;
 
     g_destroyProxyConnection = true;
+    
+   	ThreadAPI_Sleep(100);
 
     (void)printf("Received stream request (%s)\r\n", stream_request->name);
 


### PR DESCRIPTION
The streamRequestCallback, what is running in the thread set the g_destroyProxyConnection = true 
But how your ensure, that the g_uws_client_handle is not already set (what you call 2 lines below g_destroyProxyConnection = true)before destroy_proxy_connection runs in the main() thread?  And this is sometimes happening, special when you reconnect.

What is also happen, that even if you close all 2 putty’s and then you reconnect your self, the g_uws_client_handle != NULL again and immediately destroy again the session.

If you do a  ThreadAPI_Sleep(100) in, the reconnect worked. At least in my tests.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 